### PR TITLE
[CAM-11989] Health indicator exception on startup

### DIFF
--- a/spring-boot-starter/example-web/src/main/java/org/camunda/bpm/spring/boot/example/web/RestConfiguration.java
+++ b/spring-boot-starter/example-web/src/main/java/org/camunda/bpm/spring/boot/example/web/RestConfiguration.java
@@ -1,0 +1,22 @@
+package org.camunda.bpm.spring.boot.example.web;
+
+import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class RestConfiguration {
+
+    @Bean
+    public SpringProcessEngineConfiguration engineConfiguration(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        SpringProcessEngineConfiguration configuration = new SpringProcessEngineConfiguration();
+        configuration.setDataSource(dataSource);
+        configuration.setTransactionManager(transactionManager);
+        configuration.setJobExecutorActivate(true);
+        configuration.setDatabaseSchemaUpdate("true");
+        return configuration;
+    }
+}

--- a/spring-boot-starter/example-web/src/main/resources/application.yml
+++ b/spring-boot-starter/example-web/src/main/resources/application.yml
@@ -7,3 +7,5 @@ spring:
   security.user: 
     name: demo
     password: demo
+
+management.health.camunda.enabled: true


### PR DESCRIPTION
Reproducer code for:
https://jira.camunda.com/browse/CAM-11989

Throws an exception on app startup:
```
java.lang.NullPointerException: null
	at java.base/java.util.HashSet.<init>(HashSet.java:119) ~[na:na]
	at org.camunda.bpm.spring.boot.starter.actuator.JobExecutorHealthIndicator$Details.<init>(JobExecutorHealthIndicator.java:65) ~[camunda-bpm-spring-boot-starter-7.13.0.jar:7.13.0]
	at org.camunda.bpm.spring.boot.starter.actuator.JobExecutorHealthIndicator$Details.<init>(JobExecutorHealthIndicator.java:49) ~[camunda-bpm-spring-boot-starter-7.13.0.jar:7.13.0]
	at org.camunda.bpm.spring.boot.starter.actuator.JobExecutorHealthIndicator$Details$DetailsBuilder.build(JobExecutorHealthIndicator.java:147) ~[camunda-bpm-spring-boot-starter-7.13.0.jar:7.13.0]
	at org.camunda.bpm.spring.boot.starter.actuator.JobExecutorHealthIndicator$Details.from(JobExecutorHealthIndicator.java:84) ~[camunda-bpm-spring-boot-starter-7.13.0.jar:7.13.0]
	at org.camunda.bpm.spring.boot.starter.actuator.JobExecutorHealthIndicator$Details.access$000(JobExecutorHealthIndicator.java:49) ~[camunda-bpm-spring-boot-starter-7.13.0.jar:7.13.0]
	at org.camunda.bpm.spring.boot.starter.actuator.JobExecutorHealthIndicator.doHealthCheck(JobExecutorHealthIndicator.java:46) ~[camunda-bpm-spring-boot-starter-7.13.0.jar:7.13.0]
	at org.springframework.boot.actuate.health.AbstractHealthIndicator.health(AbstractHealthIndicator.java:82) ~[spring-boot-actuator-2.2.5.RELEASE.jar:2.2.5.RELEASE]
```
https://forum.camunda.org/t/jobexecutorhealthindicator-health-check-failed-java-lang-nullpointerexception-null/16312
